### PR TITLE
Fix remote execution

### DIFF
--- a/OP_RETURN.php
+++ b/OP_RETURN.php
@@ -484,7 +484,7 @@
 			$user=OP_RETURN_BITCOIN_USER;
 			$password=OP_RETURN_BITCOIN_PASSWORD;
 			
-			if (
+			if ( OP_RETURN_BITCOIN_USE_CMD &&
 				function_exists('posix_getpwuid') &&
 				!(strlen($port) && strlen($user) && strlen($password))
 			) {


### PR DESCRIPTION
Hi,

I've tested this great script but, when I run it on a Mac OS X box sending request to a externeral bitcoin full node I got following error:

````
PHP Warning:  file_get_contents(<PATH>/.bitcoin/bitcoin.conf): failed to open stream: No such file or directory in <PATH>/OP_RETURN.php on line 492
````

It seems `OP_RETURN.php` is checking for **posix_getpwuid** even when you set `OP_RETURN_BITCOIN_USE_CMD` and `OP_RETURN_BITCOIN_IP` constants

This pull request should fix this.

Thank you for your excellent work!!!