### PR TITLE
Restore Functionality with Bitcoin Versions 0.16+

### DIFF
--- a/OP_RETURN.php
+++ b/OP_RETURN.php
@@ -450,7 +450,7 @@
 
 	function OP_RETURN_bitcoin_check($testnet)
 	{
-		$info=OP_RETURN_bitcoin_cmd('getinfo', $testnet);
+		$info=OP_RETURN_bitcoin_cmd('getwalletinfo', $testnet);
 		
 		return is_array($info);
 	}


### PR DESCRIPTION
To restore the functionality of this excellent script, let's modify the command getinfo, which was deprecated and fully removed in Bitcoin version 0.16. I'm finding "getwalletinfo" is a good substitute for getinfo in my use case. In addition, start bitcoind with -deprecatedrpc=signrawtransaction. However, please note, similarly, the configuration parameter -deprecatedrpc=signrawtransaction may suffer the same fate, and be removed from future versions. For now, these patches are working.