### PR TITLE
Further Tweaks for Bitcoin Core Versions 0.18+

### DIFF
--- a/OP_RETURN.php
+++ b/OP_RETURN.php
@@ -382,7 +382,7 @@
 	
 	function OP_RETURN_sign_send_txn($raw_txn, $testnet)
 	{
-		$signed_txn=OP_RETURN_bitcoin_cmd('signrawtransaction', $testnet, $raw_txn);
+		$signed_txn=OP_RETURN_bitcoin_cmd('signrawtransactionwithwallet', $testnet, $raw_txn);
 		if (!$signed_txn['complete'])
 			return array('error' => 'Could not sign the transaction');
 			


### PR DESCRIPTION
Greetings, here is an update to my previous suggestions: the workaround solution of starting bitcoind with the "-deprecatedrpc=signrawtransaction" configuration parameter is no longer going to keep the OP_RETURN.php script running smoothly, due to the latest changes implemented with Bitcoin Core versions 0.18+. Let's consider substituting signrawtransaction with _signrawtransactionwithwallet_.